### PR TITLE
switch the github user to netlify

### DIFF
--- a/commands/netlify.go
+++ b/commands/netlify.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/calavera/netlify-go-cli/auth"
+	"github.com/netlify/netlify-go-cli/auth"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/sites.go
+++ b/commands/sites.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	tm "github.com/buger/goterm"
-	"github.com/calavera/netlify-go-cli/auth"
+	"github.com/netlify/netlify-go-cli/auth"
 	"github.com/netlify/open-api/go/plumbing"
 	"github.com/spf13/cobra"
 )

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/calavera/netlify-go-cli/commands"
+import "github.com/netlify/netlify-go-cli/commands"
 
 func main() {
 	commands.Execute()


### PR DESCRIPTION
I think reference to the import needs to be changed from calavera to netlify.

I get the following error when running `go get`:

```bash
# cd .; git clone https://github.com/calavera/netlify-go-cli /Users/bdougie/go/src/github.com/calavera/netlify-go-cli
Cloning into '/Users/bdougie/go/src/github.com/calavera/netlify-go-cli'...
fatal: could not read Username for 'https://github.com': terminal prompts disabled
package github.com/calavera/netlify-go-cli/auth: exit status 128
```
