### PR TITLE
Enable open-api debug mode when -D is set.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -14,6 +14,7 @@ func setupRunE(cmd *cobra.Command, f middleware.CommandFunc, m []middleware.Midd
 
 func addCommands() {
 	middlewares := []middleware.Middleware{
+		middleware.DebugMiddleware,
 		middleware.AuthMiddleware,
 		middleware.ClientMiddleware,
 		middleware.LoggingMiddleware,

--- a/commands/netlify.go
+++ b/commands/netlify.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/netlify/netlifyctl/auth"
 	"github.com/netlify/netlifyctl/operations"
 	"github.com/spf13/cobra"
@@ -20,15 +19,6 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "netlify",
 		Short: "Command Line Interface for netlify.com",
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			if debug {
-				logrus.SetLevel(logrus.DebugLevel)
-			}
-			logrus.WithFields(logrus.Fields{"command": cmd.Use, "arguments": args}).Debug("PreRun")
-			if debug {
-				cmd.DebugFlags()
-			}
-		},
 	}
 )
 


### PR DESCRIPTION
Use a middleware to unset the debug mode after the command runs.