### PR TITLE
Implement site update.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -20,11 +20,9 @@ func addCommands() {
 		middleware.LoggingMiddleware,
 	}
 
-	sCmd, sFunc := sites.Setup()
-	rootCmd.AddCommand(setupRunE(sCmd, sFunc, middlewares))
-
 	dCmd, dFunc := deploy.Setup()
 	rootCmd.AddCommand(setupRunE(dCmd, dFunc, middlewares))
 
+	rootCmd.AddCommand(sites.Setup(middlewares))
 	rootCmd.AddCommand(versionCmd)
 }

--- a/commands/middleware/middleware.go
+++ b/commands/middleware/middleware.go
@@ -25,6 +25,11 @@ const defaultAPIPath = "/api/v1"
 type CommandFunc func(context.Context, *cobra.Command, []string) error
 type Middleware func(CommandFunc) CommandFunc
 
+func SetupCommand(cmd *cobra.Command, f CommandFunc, m []Middleware) *cobra.Command {
+	cmd.RunE = NewRunFunc(f, m)
+	return cmd
+}
+
 func NewRunFunc(f CommandFunc, mm []Middleware) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()

--- a/commands/sites/sites.go
+++ b/commands/sites/sites.go
@@ -9,12 +9,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Setup() (*cobra.Command, middleware.CommandFunc) {
-	return &cobra.Command{
-		Use:   "sites",
-		Short: "List sites in your account",
-		Long:  "List sites in your account",
-	}, listSites
+func Setup(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "site",
+		Short: "Handle site operations",
+		Long:  "Handle site operations",
+	}
+
+	cmd.AddCommand(setupUpdateCommand(middlewares))
+
+	return middleware.SetupCommand(cmd, listSites, middlewares)
 }
 
 func listSites(ctx context.Context, cmd *cobra.Command, args []string) error {

--- a/commands/sites/update.go
+++ b/commands/sites/update.go
@@ -1,0 +1,165 @@
+package sites
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/BurntSushi/toml"
+	"github.com/netlify/netlifyctl/commands/middleware"
+	"github.com/netlify/netlifyctl/configuration"
+	"github.com/netlify/netlifyctl/context"
+	"github.com/netlify/open-api/go/models"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultEditor = "vi"
+	message       = `
+# Please modify only the fields you want to change.
+# Lines starting with '#' will be ignored, and removing all content will
+# cancel the update.
+#`
+)
+
+type siteUpdateCmd struct {
+	name         string
+	customDomain string
+	password     string
+	forceTLS     bool
+}
+
+type editableSite struct {
+	Name          string
+	CustomDomain  string
+	Password      string
+	ForceTLS      bool
+	DomainAliases []string
+}
+
+func setupUpdateCommand(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &siteUpdateCmd{}
+	ccmd := &cobra.Command{
+		Use:   "update <-n NAME> ...",
+		Short: "Add an asset to a site",
+		Long:  "Add an asset to a site",
+	}
+	ccmd.Flags().StringVarP(&cmd.name, "name", "n", "", "site's Netlify name/subdomain")
+	ccmd.Flags().StringVarP(&cmd.customDomain, "custom-domain", "c", "", "site's custom domain")
+	ccmd.Flags().StringVarP(&cmd.password, "password", "p", "", "site's access password")
+	ccmd.Flags().BoolVarP(&cmd.forceTLS, "force-tls", "t", false, "force TLS connections")
+
+	return middleware.SetupCommand(ccmd, cmd.updateSite, middlewares)
+}
+
+func (c *siteUpdateCmd) updateSite(ctx context.Context, cmd *cobra.Command, args []string) error {
+	siteId, err := configuration.SiteIdForCommand(cmd)
+	if err != nil {
+		return err
+	}
+
+	client := context.GetClient(ctx)
+	site, err := client.GetSite(ctx, siteId)
+	if err != nil {
+		return err
+	}
+
+	if c.showEditor(site) {
+		edit, err := openEditor(site)
+		if err != nil {
+			return err
+		}
+		site.Name = edit.Name
+		site.CustomDomain = edit.CustomDomain
+		site.Password = edit.Password
+		site.Ssl = edit.ForceTLS
+		site.DomainAliases = edit.DomainAliases
+	} else {
+		if c.name != "" {
+			site.Name = c.name
+		}
+		if c.customDomain != "" {
+			site.CustomDomain = c.customDomain
+		}
+		if c.password != "" {
+			site.Password = c.password
+		}
+		site.Ssl = c.forceTLS
+	}
+
+	if site.Ssl {
+		site.ForceSsl = true
+	}
+
+	updated, err := client.UpdateSite(ctx, site)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("site updated: %s", updated.URL)
+
+	return nil
+}
+
+func (c *siteUpdateCmd) showEditor(site *models.Site) bool {
+	return c.name == "" && c.customDomain == "" && c.password == "" && c.forceTLS == site.Ssl
+}
+
+func openEditor(site *models.Site) (*editableSite, error) {
+	tmpDir := os.TempDir()
+	tmpFile, err := ioutil.TempFile(tmpDir, "netlifyctl-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	es := &editableSite{
+		Name:          site.Name,
+		CustomDomain:  site.CustomDomain,
+		ForceTLS:      site.Ssl,
+		Password:      site.Password,
+		DomainAliases: site.DomainAliases,
+	}
+
+	if err := toml.NewEncoder(tmpFile).Encode(es); err != nil {
+		return nil, err
+	}
+
+	if _, err := tmpFile.WriteString(message); err != nil {
+		return nil, err
+	}
+
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = defaultEditor
+	}
+
+	cmd := exec.Command(editor, tmpFile.Name())
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadFile(tmpFile.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 0 {
+		// Cancel editing if content is empty
+		return nil, nil
+	}
+
+	if _, err := toml.Decode(string(b), es); err != nil {
+		return nil, err
+	}
+
+	return es, nil
+}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -23,6 +23,17 @@ func (c Configuration) Root() string {
 	return c.root
 }
 
+func Exist(configFile string) bool {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+
+	single := filepath.Join(pwd, configFile)
+	_, err = os.Stat(single)
+	return err == nil
+}
+
 func Load(configFile string) (*Configuration, error) {
 	pwd, err := os.Getwd()
 	if err != nil {

--- a/configuration/site.go
+++ b/configuration/site.go
@@ -1,0 +1,30 @@
+package configuration
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func SiteIdForCommand(cmd *cobra.Command) (string, error) {
+	var siteId string
+	if siteIdFlag := cmd.Flag("site-id"); siteIdFlag != nil {
+		siteId = siteIdFlag.Value.String()
+	}
+
+	var configFile = cmd.Root().Flag("config").Value.String()
+	if siteId == "" && Exist(configFile) {
+		conf, err := Load(configFile)
+		if err != nil {
+			return "", err
+		}
+
+		siteId = conf.Settings.ID
+	}
+
+	if siteId == "" {
+		return "", fmt.Errorf("missing site ID")
+	}
+
+	return siteId, nil
+}

--- a/operations/site.go
+++ b/operations/site.go
@@ -53,7 +53,8 @@ func CreateSite(cmd *cobra.Command, client *porcelain.Netlify, ctx context.Conte
 		}
 
 		site.ForceSsl = true
-		if err := client.UpdateSite(ctx, site); err != nil {
+		_, err = client.UpdateSite(ctx, site)
+		if err != nil {
 			return site, err
 		}
 	}


### PR DESCRIPTION
Allowing to modify these fields:

- Site name
- Site custom domain
- Site TLS setting
- Site password
- Domain aliases

Open editor when no flags are set.

![update](https://cloud.githubusercontent.com/assets/1050/21836311/0f93bf78-d779-11e6-8d91-e4bc480748f9.gif)


Signed-off-by: David Calavera <david.calavera@gmail.com>