### PR TITLE
Add support for creating a blank site

### DIFF
--- a/commands/deploy/deploy.go
+++ b/commands/deploy/deploy.go
@@ -21,6 +21,7 @@ type deployCmd struct {
 	title     string
 	draft     bool
 	functions string
+	siteID    string
 }
 
 func Setup() (*cobra.Command, middleware.CommandFunc) {
@@ -34,6 +35,7 @@ func Setup() (*cobra.Command, middleware.CommandFunc) {
 	ccmd.Flags().StringVarP(&cmd.title, "message", "m", "", "message for the deploy title")
 	ccmd.Flags().BoolVarP(&cmd.draft, "draft", "d", false, "draft deploy, not published in production")
 	ccmd.Flags().StringVarP(&cmd.functions, "functions", "f", "", "function directory to deploy")
+	ccmd.Flags().StringVarP(&cmd.siteID, "site-id", "s", "", "explicitly set a site id instead of relying on configuration")
 
 	return ccmd, cmd.deploySite
 }
@@ -42,6 +44,10 @@ func (dc *deployCmd) deploySite(ctx context.Context, cmd *cobra.Command, args []
 	conf, err := middleware.ChooseSiteConf(ctx, cmd)
 	if err != nil {
 		return err
+	}
+
+	if dc.siteID != "" {
+		conf.Settings.ID = dc.siteID
 	}
 
 	fmt.Println("=> Domain ready, deploying assets")

--- a/commands/sites/create.go
+++ b/commands/sites/create.go
@@ -1,0 +1,70 @@
+package sites
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/netlify/netlifyctl/commands/middleware"
+	"github.com/netlify/netlifyctl/configuration"
+	"github.com/netlify/netlifyctl/context"
+	"github.com/netlify/netlifyctl/operations"
+	"github.com/netlify/open-api/go/models"
+	"github.com/spf13/cobra"
+)
+
+type siteCreateCmd struct {
+	name         string
+	customDomain string
+	password     string
+	forceTLS     bool
+	sessionID    string
+}
+
+func setupCreateCommand(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &siteCreateCmd{}
+	ccmd := &cobra.Command{
+		Use:   "create <-n NAME> ...",
+		Short: "create site",
+		Long:  "create site",
+	}
+	ccmd.Flags().StringVarP(&cmd.name, "name", "n", "", "site's Netlify name/subdomain")
+	ccmd.Flags().StringVarP(&cmd.customDomain, "custom-domain", "c", "", "site's custom domain")
+	ccmd.Flags().StringVarP(&cmd.password, "password", "p", "", "site's access password")
+	ccmd.Flags().BoolVarP(&cmd.forceTLS, "force-tls", "t", false, "force TLS connections")
+	ccmd.Flags().StringVarP(&cmd.sessionID, "session-id", "s", "", "Session ID for later site transfers")
+
+	return middleware.SetupCommand(ccmd, cmd.createSite, middlewares)
+}
+
+func (c *siteCreateCmd) createSite(ctx context.Context, cmd *cobra.Command, args []string) error {
+	var configFile = cmd.Root().Flag("config").Value.String()
+	var conf, err = configuration.Load(configFile)
+	if err != nil {
+		return err
+	}
+	if conf.Settings.ID != "" {
+		if !operations.ConfirmOverwriteSite(cmd) {
+			return errors.New("Canceled")
+		}
+	}
+
+	site := &models.Site{
+		CustomDomain: c.customDomain,
+		Name:         c.name,
+		Password:     c.password,
+		Ssl:          c.forceTLS,
+		SessionID:    c.sessionID,
+	}
+	client := context.GetClient(ctx)
+
+	fmt.Println("Creating site")
+	site, err = operations.CreateSite(client, ctx, site)
+
+	if err == nil {
+		conf.Settings.ID = site.ID
+		configuration.Save(configFile, conf)
+		fmt.Printf("=> Done, create website with %s\n", site.ID)
+	}
+
+	return err
+}

--- a/commands/sites/sites.go
+++ b/commands/sites/sites.go
@@ -17,6 +17,7 @@ func Setup(middlewares []middleware.Middleware) *cobra.Command {
 	}
 
 	cmd.AddCommand(setupUpdateCommand(middlewares))
+	cmd.AddCommand(setupCreateCommand(middlewares))
 
 	return middleware.SetupCommand(cmd, listSites, middlewares)
 }

--- a/commands/sites/update.go
+++ b/commands/sites/update.go
@@ -42,8 +42,8 @@ func setupUpdateCommand(middlewares []middleware.Middleware) *cobra.Command {
 	cmd := &siteUpdateCmd{}
 	ccmd := &cobra.Command{
 		Use:   "update <-n NAME> ...",
-		Short: "Add an asset to a site",
-		Long:  "Add an asset to a site",
+		Short: "Update site settings",
+		Long:  "Update site settings",
 	}
 	ccmd.Flags().StringVarP(&cmd.name, "name", "n", "", "site's Netlify name/subdomain")
 	ccmd.Flags().StringVarP(&cmd.customDomain, "custom-domain", "c", "", "site's custom domain")

--- a/glide.lock
+++ b/glide.lock
@@ -1,40 +1,40 @@
-hash: 205c8102e4ae38989511c413f9ad3f97e386ad1199068c9bc2668157842a3361
-updated: 2017-10-17T15:19:56.130991174-07:00
+hash: ea8706ba4cd07f999c2a584c18793e68d2bc06d0da9a4769f7430533a082b24a
+updated: 2017-10-09T22:23:33.937175156-07:00
 imports:
 - name: github.com/asaskevich/govalidator
-  version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
+  version: ca5f9e638c83bac66bfac70ded5bded1503135a7
 - name: github.com/buger/goterm
-  version: cc3942e537b1ab00de92d348c40acbfa6565d20f
+  version: d443b9114f9c050367638a536310fbec36a0de11
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
 - name: github.com/cenkalti/backoff
-  version: 32cd0c5b3aef12c76ed64aaf678f6c79736be7dc
+  version: 61ba96c4d1002f22e06acb8e34a7650611125a63
 - name: github.com/go-openapi/analysis
-  version: 7222828b8ce19afee3c595aef6643b9e42150120
+  version: 8ed83f2ea9f00f945516462951a288eaa68bf0d6
 - name: github.com/go-openapi/errors
   version: 03cfca65330da08a5a440053faf994a3c682b5bf
 - name: github.com/go-openapi/jsonpointer
-  version: 8d96a2dc61536b690bd36b2e9df0b3c0b62825b2
+  version: 779f45308c19820f1a69e9a4cd965f496e0da10f
 - name: github.com/go-openapi/jsonreference
   version: 36d33bfe519efae5632669801b180bf1a245da3b
 - name: github.com/go-openapi/loads
-  version: 5861a4879a2866943dce3c644c879af9e59c22a3
+  version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
 - name: github.com/go-openapi/runtime
-  version: e255829c65ab152686ddbb608d57c2b93e28b899
+  version: bf2ff8f7150788b1c7256abb0805ba0410cbbabb
   subpackages:
   - client
 - name: github.com/go-openapi/spec
-  version: f7ae86df5bc115a2744343016c789a89f065a4bd
+  version: 48c2a7185575f9103a5a3863eff950bb776899d2
 - name: github.com/go-openapi/strfmt
-  version: 34fc3ba7c0f5fb615fda47a2b4fbd4c641b215f2
+  version: 610b6cacdcde6852f4de68998bd20ce1dac85b22
 - name: github.com/go-openapi/swag
-  version: 3b6d86cd965820f968760d5d419cb4add096bdd7
+  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/go-openapi/validate
-  version: 027696d4b54399770f1cdcc6c6daa56975f9e14e
+  version: dc8a684882cf70c9a529887104340f44e0e138e5
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/mailru/easyjson
-  version: 159cdb893c982e3d1bc6450322fedd514f9c9de3
+  version: 2a92e673c9a6302dd05c3a691ae1f24aef46457d
   subpackages:
   - buffer
   - jlexer
@@ -42,9 +42,9 @@ imports:
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/netlify/open-api
-  version: 9d16db737b26d7349b971117f55925e68de61596
+  version: 7f676b8947f434c100e248ebb5864c042d7bd2e8
   vcs: git
   subpackages:
   - go/models
@@ -53,9 +53,9 @@ imports:
   - go/porcelain
   - go/porcelain/context
 - name: github.com/PuerkitoBio/purell
-  version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
+  version: fd18e053af8a4ff11039269006e8037ff374ce0e
 - name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  version: de5bf2ad457846296e2031421a34e2568e304e35
 - name: github.com/sirupsen/logrus
   version: d26492970760ca5d33129d2d799e34be5c4782eb
 - name: github.com/skratchdot/open-golang
@@ -63,25 +63,30 @@ imports:
   subpackages:
   - open
 - name: github.com/spf13/cobra
-  version: 4a7b7e65864c064d48dce82efbbfed2bdc0bf2aa
+  version: fcd0c5a1df88f5d6784cb4feead962c3f3d0b66c
 - name: github.com/spf13/pflag
-  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: d379faa25cbdc04d653984913a2ceb43b0bc46d7
   subpackages:
   - context
   - context/ctxhttp
   - idna
 - name: golang.org/x/sys
-  version: 07c182904dbd53199946ba614a412c61d3c548f5
+  version: e48874b42435b4347fc52bdee0424a52abc974d7
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: e56139fd9c5bc7244c76116c68e500765bb6db6b
+  version: f28f36722d5ef2f9655ad3de1f248e3e52ad5ebd
   subpackages:
-  - secure/bidirule
   - transform
-  - unicode/bidi
   - unicode/norm
   - width
+- name: gopkg.in/mgo.v2
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
+  subpackages:
+  - bson
+  - internal/json
+- name: gopkg.in/yaml.v2
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
 - package: github.com/go-openapi/strfmt
 - package: github.com/netlify/open-api
   vcs: git
-  version: 9d16db737b26d7349b971117f55925e68de61596
+  version: 7f676b8947f434c100e248ebb5864c042d7bd2e8
   subpackages:
   - go/models
   - go/porcelain

--- a/operations/site.go
+++ b/operations/site.go
@@ -23,6 +23,14 @@ func ConfirmCreateSite(cmd *cobra.Command) bool {
 	return askForConfirmation("We cannot find a site for this repository, do you want to create a new one?")
 }
 
+func ConfirmOverwriteSite(cmd *cobra.Command) bool {
+	if AssumeYes {
+		return true
+	}
+
+	return askForConfirmation("There's already a site ID stored for this folder. Ignore and create a new site?")
+}
+
 func CreateSite(client *porcelain.Netlify, ctx context.Context) (*models.Site, error) {
 	domain, err := AskForInput("Type your domain or press enter to use a Netlify subdomain:", "", validateCustomDomain)
 	if err != nil {

--- a/operations/site.go
+++ b/operations/site.go
@@ -31,20 +31,21 @@ func ConfirmOverwriteSite(cmd *cobra.Command) bool {
 	return askForConfirmation("There's already a site ID stored for this folder. Ignore and create a new site?")
 }
 
-func CreateSite(client *porcelain.Netlify, ctx context.Context) (*models.Site, error) {
-	domain, err := AskForInput("Type your domain or press enter to use a Netlify subdomain:", "", validateCustomDomain)
-	if err != nil {
-		return nil, err
-	}
-
-	newS := &models.Site{
-		CustomDomain: domain,
+func CreateSite(client *porcelain.Netlify, ctx context.Context, newS *models.Site) (*models.Site, error) {
+	if newS == nil {
+		domain, err := AskForInput("Type your domain or press enter to use a Netlify subdomain:", "", validateCustomDomain)
+		if err != nil {
+			return nil, err
+		}
+		newS = &models.Site{
+			CustomDomain: domain,
+		}
 	}
 
 	// Only configure DNS and TLS for custom domains.
 	// Netlify hosted sites don't need DNS entries
 	// and the connection is always over TLS.
-	withTLS := len(domain) > 0
+	withTLS := len(newS.CustomDomain) > 0
 
 	site, err := client.CreateSite(ctx, newS, withTLS)
 	if err != nil {
@@ -104,7 +105,7 @@ func ChooseOrCreateSite(client *porcelain.Netlify, ctx context.Context) (*models
 			if id == 0 {
 				// in this case we want to do whatever the create says
 				// that includes storing off the new id
-				return CreateSite(client, ctx)
+				return CreateSite(client, ctx, nil)
 			}
 
 			if id > len(sites) || id < 0 {


### PR DESCRIPTION
This is useful when explcitly creating a site with a session id
before deploying.