### PR TITLE
Add Site assets commands.

### DIFF
--- a/commands/assets/add.go
+++ b/commands/assets/add.go
@@ -1,0 +1,151 @@
+package assets
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"os"
+
+	"github.com/netlify/netlifyctl/commands/middleware"
+	"github.com/netlify/netlifyctl/context"
+	"github.com/netlify/open-api/go/models"
+	"github.com/netlify/open-api/go/plumbing/operations"
+	"github.com/spf13/cobra"
+)
+
+const (
+	uploadedAssetState     = "uploaded"
+	privateAssetVisibility = "private"
+)
+
+type assetsAddCmd struct {
+	private bool
+}
+
+func setupAddCommand(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &assetsAddCmd{}
+	ccmd := &cobra.Command{
+		Use:   "add [ASSET PATH 1] [ASSET PATH 2] ...",
+		Short: "Add an asset to a site",
+		Long:  "Add an asset to a site",
+	}
+	ccmd.Flags().BoolVarP(&cmd.private, "private", "p", false, "make the asset private")
+
+	return middleware.SetupCommand(ccmd, cmd.AddAsset, middlewares)
+}
+
+func (c *assetsAddCmd) AddAsset(ctx context.Context, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing asset paths to upload")
+	}
+
+	siteId, err := siteIdForCommand(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	dups := make(map[string]os.FileInfo)
+	for _, arg := range args {
+		fi, err := os.Stat(arg)
+		if err != nil {
+			return fmt.Errorf("unable to access asset with path %s, all assets must exist: %v", arg, err)
+		}
+
+		if _, dup := dups[arg]; dup {
+			fmt.Printf("[WARNING] duplicated asset %s, will be uploaded only once\n", arg)
+		}
+
+		dups[arg] = fi
+	}
+
+	params := operations.NewCreateSiteAssetParams().WithSiteID(siteId)
+	if c.private {
+		visibility := privateAssetVisibility
+		params = params.WithVisibility(&visibility)
+	}
+
+	for fp, fi := range dups {
+		asset, err := c.uploadAsset(ctx, siteId, fp, fi, params)
+		if err != nil {
+			fmt.Printf("%s upload failed: %v", fp, err)
+			break
+		}
+
+		fmt.Printf("%s available at %s\n", fp, asset.URL)
+	}
+
+	return nil
+}
+
+func (c *assetsAddCmd) uploadAsset(ctx context.Context, siteId string, fp string, fi os.FileInfo, baseParams *operations.CreateSiteAssetParams) (*models.Asset, error) {
+	client := context.GetClient(ctx)
+
+	body, err := os.Open(fp)
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+
+	buffer := make([]byte, 512)
+	n, err := body.Read(buffer)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	contentType := http.DetectContentType(buffer[:n])
+	body.Seek(0, 0)
+
+	params := baseParams.WithName(fi.Name()).WithSize(fi.Size()).WithContentType(contentType)
+
+	signature, err := client.AddSiteAsset(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	bufferWriter := &bytes.Buffer{}
+	writer := multipart.NewWriter(bufferWriter)
+	defer writer.Close()
+
+	for key, value := range signature.Form.Fields {
+		writer.WriteField(key, value)
+	}
+
+	part, err := writer.CreateFormFile("file", fi.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = io.Copy(part, body); err != nil {
+		return nil, err
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", signature.Form.URL, bufferWriter)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusCreated {
+		defer resp.Body.Close()
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("unexpected error uploading assets to the :cloud: %d - %s", resp.StatusCode, respBody)
+	}
+
+	updateParams := operations.NewUpdateSiteAssetParams().WithSiteID(siteId).WithAssetID(signature.Asset.ID).WithState(uploadedAssetState)
+
+	return client.UpdateSiteAsset(ctx, updateParams)
+}

--- a/commands/assets/assets.go
+++ b/commands/assets/assets.go
@@ -1,0 +1,41 @@
+package assets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/netlify/netlifyctl/commands/middleware"
+	"github.com/spf13/cobra"
+)
+
+func Setup(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "assets",
+		Short: "List assets attached to a site",
+		Long:  "List assets attached to a site",
+	}
+	cmd.PersistentFlags().StringP("site-id", "s", "", "site id")
+
+	cmd.AddCommand(setupAddCommand(middlewares))
+	cmd.AddCommand(setupInfoCommand(middlewares))
+
+	return middleware.SetupCommand(cmd, listAssets, middlewares)
+}
+
+func siteIdForCommand(ctx context.Context, cmd *cobra.Command) (string, error) {
+	siteId := cmd.Flag("site-id").Value.String()
+
+	if siteId == "" {
+		conf, err := middleware.ChooseSiteConf(ctx, cmd)
+		if err != nil {
+			return "", err
+		}
+		siteId = conf.Settings.ID
+	}
+
+	if siteId == "" {
+		return "", fmt.Errorf("missing site ID to add assets to")
+	}
+
+	return siteId, nil
+}

--- a/commands/assets/info.go
+++ b/commands/assets/info.go
@@ -1,0 +1,59 @@
+package assets
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/netlify/netlifyctl/commands/middleware"
+	"github.com/netlify/netlifyctl/context"
+	"github.com/netlify/open-api/go/plumbing/operations"
+	"github.com/spf13/cobra"
+)
+
+type assetsShowCmd struct {
+	withSignature bool
+}
+
+func setupInfoCommand(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &assetsShowCmd{}
+	ccmd := &cobra.Command{
+		Use:   "info [ASSET ID 1] [ASSET ID 2] ...",
+		Short: "Show information for an asset or a group of them",
+		Long:  "Show information for an asset or a group of them",
+	}
+	ccmd.Flags().BoolVarP(&cmd.withSignature, "with-public-signature", "p", false, "show public signature of private assets")
+
+	return middleware.SetupCommand(ccmd, cmd.showAssets, middlewares)
+}
+
+func (c *assetsShowCmd) showAssets(ctx context.Context, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing asset ids to show")
+	}
+
+	siteId, err := siteIdForCommand(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	client := context.GetClient(ctx)
+	for i, arg := range args {
+		params := operations.NewGetSiteAssetInfoParams().WithSiteID(siteId).WithAssetID(arg)
+
+		asset, err := client.ShowSiteAssetInfo(ctx, params, c.withSignature)
+		if err != nil {
+			return err
+		}
+
+		b, err := json.MarshalIndent(asset, "", "\t")
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(string(b))
+		if i+1 < len(args) {
+			fmt.Print("\n")
+		}
+	}
+	return nil
+}

--- a/commands/assets/list.go
+++ b/commands/assets/list.go
@@ -1,0 +1,35 @@
+package assets
+
+import (
+	"fmt"
+
+	tm "github.com/buger/goterm"
+	"github.com/netlify/netlifyctl/context"
+	"github.com/netlify/open-api/go/plumbing/operations"
+	"github.com/spf13/cobra"
+)
+
+func listAssets(ctx context.Context, cmd *cobra.Command, args []string) error {
+	client := context.GetClient(ctx)
+
+	siteId, err := siteIdForCommand(ctx, cmd)
+	if err != nil {
+		return err
+	}
+
+	params := operations.NewListSiteAssetsParams().WithSiteID(siteId)
+	assets, err := client.ListSiteAssets(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	table := tm.NewTable(0, 10, 5, ' ', 0)
+	fmt.Fprintf(table, "ID\tNAME\tVISIBILITY\tURL")
+	for _, a := range assets {
+		fmt.Fprintf(table, "\n%s\t%s\t%s\t%s", a.ID, a.Name, a.Visibility, a.URL)
+	}
+	tm.Print(table)
+	tm.Flush()
+
+	return nil
+}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,17 +1,12 @@
 package commands
 
 import (
+	"github.com/netlify/netlifyctl/commands/assets"
 	"github.com/netlify/netlifyctl/commands/deploy"
 	"github.com/netlify/netlifyctl/commands/login"
 	"github.com/netlify/netlifyctl/commands/middleware"
 	"github.com/netlify/netlifyctl/commands/sites"
-	"github.com/spf13/cobra"
 )
-
-func setupRunE(cmd *cobra.Command, f middleware.CommandFunc, m []middleware.Middleware) *cobra.Command {
-	cmd.RunE = middleware.NewRunFunc(f, m)
-	return cmd
-}
 
 func addCommands() {
 	loginMiddleware := []middleware.Middleware{
@@ -28,8 +23,9 @@ func addCommands() {
 	}
 
 	dCmd, dFunc := deploy.Setup()
-	rootCmd.AddCommand(setupRunE(dCmd, dFunc, middlewares))
+	rootCmd.AddCommand(middleware.SetupCommand(dCmd, dFunc, middlewares))
 
+	rootCmd.AddCommand(assets.Setup(middlewares))
 	rootCmd.AddCommand(sites.Setup(middlewares))
 	rootCmd.AddCommand(login.Setup(loginMiddleware))
 	rootCmd.AddCommand(versionCmd)

--- a/commands/netlify.go
+++ b/commands/netlify.go
@@ -10,10 +10,9 @@ import (
 	aoperations "github.com/netlify/open-api/go/plumbing/operations"
 
 	"github.com/netlify/netlifyctl/auth"
+	"github.com/netlify/netlifyctl/configuration"
 	"github.com/netlify/netlifyctl/operations"
 )
-
-const globalConfigFileName = "netlify.toml"
 
 var (
 	configFile string
@@ -21,7 +20,7 @@ var (
 	endpoint   string
 
 	rootCmd = &cobra.Command{
-		Use:   "netlify",
+		Use:   "netlifyctl",
 		Short: "Command Line Interface for netlify.com",
 	}
 )
@@ -32,7 +31,7 @@ func Execute() {
 	rootCmd.SilenceErrors = true
 
 	rootCmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "E", "https://api.netlify.com", "default API endpoint")
-	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "C", globalConfigFileName, "configuration file")
+	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "C", configuration.DefaultConfigFileName, "configuration file")
 	rootCmd.PersistentFlags().StringVarP(&auth.AccessToken, "access-token", "A", "", "access token for Netlify's API")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "enable debug tracing")
 

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const DefaultConfigFileName = "netlify.toml"
+
 type Settings struct {
 	ID   string
 	Path string

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5fcb0621a9784a302dcfc5e63d2570e53188ebc788d7d4f10fc71547ab7863cd
-updated: 2017-08-28T16:10:12.692000917-07:00
+hash: 205c8102e4ae38989511c413f9ad3f97e386ad1199068c9bc2668157842a3361
+updated: 2017-10-17T15:19:56.130991174-07:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
@@ -44,7 +44,7 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/netlify/open-api
-  version: dd9014639bf81e12e819ebc659d2bc290e614975
+  version: 9d16db737b26d7349b971117f55925e68de61596
   vcs: git
   subpackages:
   - go/models

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
 - package: github.com/go-openapi/strfmt
 - package: github.com/netlify/open-api
   vcs: git
-  version: dd9014639bf81e12e819ebc659d2bc290e614975
+  version: 9d16db737b26d7349b971117f55925e68de61596
   subpackages:
   - go/models
   - go/porcelain


### PR DESCRIPTION
- `asset add` to upload an asset for a site.
- `asset list` to list all the assets for a site.
- `asset info` to show the information for a specific asset.

It requires this version of open-api https://github.com/netlify/open-api/pull/27

Signed-off-by: David Calavera <david.calavera@gmail.com>