### PR TITLE
Turn debug log always on.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -12,15 +12,15 @@ import (
 func addCommands() {
 	loginMiddleware := []middleware.Middleware{
 		middleware.DebugMiddleware,
+		middleware.LoggingMiddleware,
 		middleware.NoAuthMiddleware,
 		middleware.ClientMiddleware,
-		middleware.LoggingMiddleware,
 	}
 	middlewares := []middleware.Middleware{
 		middleware.DebugMiddleware,
+		middleware.LoggingMiddleware,
 		middleware.AuthMiddleware,
 		middleware.ClientMiddleware,
-		middleware.LoggingMiddleware,
 	}
 
 	rootCmd.AddCommand(deploy.Setup(middlewares))

--- a/commands/netlify.go
+++ b/commands/netlify.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	configFile string
-	debug      bool
 	endpoint   string
 
 	rootCmd = &cobra.Command{
@@ -33,7 +32,6 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "E", "https://api.netlify.com", "default API endpoint")
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "C", configuration.DefaultConfigFileName, "configuration file")
 	rootCmd.PersistentFlags().StringVarP(&auth.AccessToken, "access-token", "A", "", "access token for Netlify's API")
-	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "enable debug tracing")
 
 	rootCmd.PersistentFlags().BoolVarP(&operations.AssumeYes, "yes", "y", false, "automatic yes to confirmation prompts")
 

--- a/commands/netlify.go
+++ b/commands/netlify.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	configFile string
+	dump       bool
 	endpoint   string
 
 	rootCmd = &cobra.Command{
@@ -32,6 +33,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&endpoint, "endpoint", "E", "https://api.netlify.com", "default API endpoint")
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "C", configuration.DefaultConfigFileName, "configuration file")
 	rootCmd.PersistentFlags().StringVarP(&auth.AccessToken, "access-token", "A", "", "access token for Netlify's API")
+	rootCmd.PersistentFlags().BoolVarP(&dump, "debug", "D", false, "dump debug tracing, even if there are no errors")
 
 	rootCmd.PersistentFlags().BoolVarP(&operations.AssumeYes, "yes", "y", false, "automatic yes to confirmation prompts")
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2b0a7a022fca1e07fadb5f050471d92bb2eee56cba6270bac6213b6d34b68690
-updated: 2017-11-11T16:02:00.378022522-08:00
+hash: 5c33c94f1ff991464539629c6a98d5f00115845d08e5fb36cb5704df910cfa44
+updated: 2017-11-12T14:17:03.907485022-08:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: ca5f9e638c83bac66bfac70ded5bded1503135a7
@@ -33,9 +33,15 @@ imports:
 - name: github.com/go-openapi/loads
   version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
 - name: github.com/go-openapi/runtime
-  version: bf2ff8f7150788b1c7256abb0805ba0410cbbabb
+  version: 96511efa8f2190cf4dd04412c61a1a96546b36d9
   subpackages:
   - client
+  - logger
+  - middleware
+  - middleware/denco
+  - middleware/header
+  - middleware/untyped
+  - security
 - name: github.com/go-openapi/spec
   version: 48c2a7185575f9103a5a3863eff950bb776899d2
 - name: github.com/go-openapi/strfmt

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,8 +6,8 @@ import:
   version: v0.11.0
 - package: github.com/buger/goterm
 - package: github.com/go-openapi/errors
-  version: 03cfca65330da08a5a440053faf994a3c682b5bf
 - package: github.com/go-openapi/runtime
+  version: 96511efa8f2190cf4dd04412c61a1a96546b36d9
   subpackages:
   - client
 - package: github.com/go-openapi/strfmt


### PR DESCRIPTION
This allows people to have a debug log right away that can share with
Netlify for troubleshooting.

- Keep the log in memory.
- Dump it to a file if there is an error before terminating the command.

Signed-off-by: David Calavera <david.calavera@gmail.com>