### PR TITLE
Fix site listing with sites overflowing the screen size.

### DIFF
--- a/commands/assets/list.go
+++ b/commands/assets/list.go
@@ -1,9 +1,11 @@
 package assets
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"text/tabwriter"
 
-	tm "github.com/buger/goterm"
 	"github.com/netlify/netlifyctl/context"
 	"github.com/netlify/open-api/go/plumbing/operations"
 	"github.com/spf13/cobra"
@@ -23,13 +25,15 @@ func listAssets(ctx context.Context, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	table := tm.NewTable(0, 10, 5, ' ', 0)
-	fmt.Fprintf(table, "ID\tNAME\tVISIBILITY\tURL")
+	t := tabwriter.NewWriter(os.Stdout, 0, 10, 5, ' ', 0)
+	buffer := new(bytes.Buffer)
+
+	fmt.Fprintf(buffer, "Id\tName\tVisibility\tUrl")
 	for _, a := range assets {
-		fmt.Fprintf(table, "\n%s\t%s\t%s\t%s", a.ID, a.Name, a.Visibility, a.URL)
+		fmt.Fprintf(buffer, "\n%s\t%s\t%s\t%s", a.ID, a.Name, a.Visibility, a.URL)
 	}
-	tm.Print(table)
-	tm.Flush()
+	buffer.WriteTo(t)
+	t.Flush()
 
 	return nil
 }

--- a/commands/sites/sites.go
+++ b/commands/sites/sites.go
@@ -1,9 +1,11 @@
 package sites
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"text/tabwriter"
 
-	tm "github.com/buger/goterm"
 	"github.com/netlify/netlifyctl/commands/middleware"
 	"github.com/netlify/netlifyctl/context"
 	"github.com/spf13/cobra"
@@ -30,13 +32,15 @@ func listSites(ctx context.Context, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	table := tm.NewTable(0, 10, 5, ' ', 0)
-	fmt.Fprintf(table, "SITE\tURL")
+	t := tabwriter.NewWriter(os.Stdout, 0, 10, 5, ' ', 0)
+	buffer := new(bytes.Buffer)
+
+	fmt.Fprintf(buffer, "Site\tUrl")
 	for _, s := range sites {
-		fmt.Fprintf(table, "\n%s\t%s", s.Name, s.URL)
+		fmt.Fprintf(buffer, "\n%s\t%s", s.Name, s.URL)
 	}
-	tm.Print(table)
-	tm.Flush()
+	buffer.WriteTo(t)
+	t.Flush()
 
 	return nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -3,8 +3,6 @@ updated: 2017-11-12T14:17:03.907485022-08:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: ca5f9e638c83bac66bfac70ded5bded1503135a7
-- name: github.com/buger/goterm
-  version: d443b9114f9c050367638a536310fbec36a0de11
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
 - name: github.com/cenkalti/backoff

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,6 @@ import:
   version: v0.2.0
 - package: github.com/sirupsen/logrus
   version: v0.11.0
-- package: github.com/buger/goterm
 - package: github.com/go-openapi/errors
 - package: github.com/go-openapi/runtime
   version: 96511efa8f2190cf4dd04412c61a1a96546b36d9


### PR DESCRIPTION
For some weird reason, the library we were using doesn't print
if the information to print overflows the screen height.
That behaviour is very unexpected and wrong.
This removes that library and uses tabwriter directly, removing one
dependency and doing the right thing.

Signed-off-by: David Calavera <david.calavera@gmail.com>