### PR TITLE
Reverse middlewares ordering.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -11,20 +11,20 @@ import (
 
 func addCommands() {
 	middlewares := []middleware.Middleware{
-		middleware.DebugMiddleware,
-		middleware.LoggingMiddleware,
-		middleware.AuthMiddleware,
 		middleware.ClientMiddleware,
+		middleware.AuthMiddleware,
+		middleware.LoggingMiddleware,
+		middleware.DebugMiddleware,
 	}
 
 	loginMiddlewares := []middleware.Middleware{
-		middleware.DebugMiddleware,
-		middleware.LoggingMiddleware,
-		middleware.NoAuthMiddleware,
 		middleware.ClientMiddleware,
+		middleware.NoAuthMiddleware,
+		middleware.LoggingMiddleware,
+		middleware.DebugMiddleware,
 	}
 
-	siteMiddlewares := append(middlewares, middleware.SiteConfigMiddleware)
+	siteMiddlewares := append([]middleware.Middleware{middleware.SiteConfigMiddleware}, middlewares...)
 
 	rootCmd.AddCommand(deploy.Setup(siteMiddlewares))
 	rootCmd.AddCommand(assets.Setup(siteMiddlewares))

--- a/commands/middleware/middleware.go
+++ b/commands/middleware/middleware.go
@@ -65,6 +65,8 @@ func DebugMiddleware(cmd CommandFunc) CommandFunc {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.WithFields(logrus.Fields{"command": c.Use, "arguments": args}).Debug("PreRun")
 
+		logrus.Debug("configure debug middleware")
+
 		dump, err := c.Root().Flags().GetBool("debug")
 		if err != nil {
 			return err
@@ -106,6 +108,7 @@ func DebugMiddleware(cmd CommandFunc) CommandFunc {
 
 func LoggingMiddleware(cmd CommandFunc) CommandFunc {
 	return func(ctx context.Context, c *cobra.Command, args []string) error {
+		logrus.Debug("configure logging middleware")
 		entry := logrus.NewEntry(logrus.StandardLogger())
 		entry.Debugf("setup logger middleware: %v", entry.Level)
 		ctx = apiContext.WithLogger(ctx, entry)
@@ -116,6 +119,7 @@ func LoggingMiddleware(cmd CommandFunc) CommandFunc {
 
 func AuthMiddleware(cmd CommandFunc) CommandFunc {
 	return func(ctx context.Context, c *cobra.Command, args []string) error {
+		logrus.Debug("configure auth middleware")
 		creds := auth.ClientCredentials()
 		logrus.WithField("credentials", creds).Debug("setup credentials")
 
@@ -127,6 +131,7 @@ func AuthMiddleware(cmd CommandFunc) CommandFunc {
 
 func NoAuthMiddleware(cmd CommandFunc) CommandFunc {
 	return func(ctx context.Context, c *cobra.Command, args []string) error {
+		logrus.Debug("configure no auth middleware")
 		creds := auth.NoCredentials()
 		logrus.WithField("credentials", creds).Debug("setup credentials")
 
@@ -138,6 +143,7 @@ func NoAuthMiddleware(cmd CommandFunc) CommandFunc {
 
 func ClientMiddleware(cmd CommandFunc) CommandFunc {
 	return func(ctx context.Context, c *cobra.Command, args []string) error {
+		logrus.Debug("configure client middleware")
 		var transport *apiClient.Runtime
 
 		if endpoint := c.Flag("endpoint"); endpoint != nil {
@@ -180,6 +186,7 @@ func ClientMiddleware(cmd CommandFunc) CommandFunc {
 
 func SiteConfigMiddleware(cmd CommandFunc) CommandFunc {
 	return func(ctx context.Context, c *cobra.Command, args []string) error {
+		logrus.Debug("configure site middleware")
 		var siteId string
 		if siteIdFlag := c.Flag("site-id"); siteIdFlag != nil {
 			siteId = siteIdFlag.Value.String()

--- a/commands/sites/update.go
+++ b/commands/sites/update.go
@@ -50,7 +50,7 @@ func setupUpdateCommand(middlewares []middleware.Middleware) *cobra.Command {
 	ccmd.Flags().StringVarP(&cmd.password, "password", "p", "", "site's access password")
 	ccmd.Flags().BoolVarP(&cmd.forceTLS, "force-tls", "t", false, "force TLS connections")
 
-	siteMiddlewares := append(middlewares, middleware.SiteConfigMiddleware)
+	siteMiddlewares := append([]middleware.Middleware{middleware.SiteConfigMiddleware}, middlewares...)
 
 	return middleware.SetupCommand(ccmd, cmd.updateSite, siteMiddlewares)
 }


### PR DESCRIPTION
This ensure that the api client is configured before any call to the api.

Fixes #77

Signed-off-by: David Calavera <david.calavera@gmail.com>