### PR TITLE
Disable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ arch = amd64
 
 build: test
 	@echo "Making netlifyctl for $(os)/$(arch)"
-	GOOS=$(os) GOARCH=$(arch) go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`"
+	GOOS=$(os) GOARCH=$(arch) CGO_ENABLED=0 go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`"
 
 build_linux: override os=linux ## Build the binary for Linux hosts.
 build_linux: build
@@ -32,11 +32,11 @@ package_windows: package
 
 release: ## Upload release to GitHub releases.
 	mkdir -p builds/darwin-${TAG}
-	GOOS=darwin GOARCH=$(arch) go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`" -o builds/darwin-${TAG}/netlifyctl
+	GOOS=darwin GOARCH=$(arch) CGO_ENABLED=0 go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`" -o builds/darwin-${TAG}/netlifyctl
 	mkdir -p builds/linux-${TAG}
-	GOOS=linux GOARCH=$(arch) go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`" -o builds/linux-${TAG}/netlifyctl
+	GOOS=linux GOARCH=$(arch) CGO_ENABLED=0 go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`" -o builds/linux-${TAG}/netlifyctl
 	mkdir -p builds/windows-${TAG}
-	GOOS=windows GOARCH=$(arch) go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`" -o builds/windows-${TAG}/netlifyctl.exe
+	GOOS=windows GOARCH=$(arch) CGO_ENABLED=0 go build -ldflags "-X github.com/netlify/netlifyctl/commands.Version=${TAG} -X github.com/netlify/netlifyctl/commands.SHA=`git rev-parse HEAD`" -o builds/windows-${TAG}/netlifyctl.exe
 	@rm -rf releases/${TAG}
 	mkdir -p releases/${TAG}
 	tar -czf releases/${TAG}/netlifyctl-darwin-$(arch)-${TAG}.tar.gz -C builds/darwin-${TAG} netlifyctl


### PR DESCRIPTION
Build with CGO disabled, and generate standalone binary.

This makes it possible to run prebuilt release binaries on Alpine Linux and Docker's scratch image as well.

### before

```console
$ ldd $(which netlifyctl)
	linux-vdso.so.1 (0x00007ffec51f7000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f1f2ecba000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f1f2e91b000)
	/lib64/ld-linux-x86-64.so.2 (0x0000557c3dbb5000)
```

### after

```console
$ ldd $(which netlifyctl)
	not a dynamic executable
```