### PR TITLE
Ignore term animations in manual init command.

### DIFF
--- a/commands/init/init.go
+++ b/commands/init/init.go
@@ -31,9 +31,11 @@ func initSite(ctx context.Context, cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	tt := ui.NewTaskTracker()
 	var c configurator
 	if manual {
 		c = manualConfigurator{host}
+		tt = ui.NewTaskTrackerWithTerm(false)
 	} else {
 		ec, err := loadConfigurator(ctx, host.URL)
 		if err != nil {
@@ -74,7 +76,7 @@ func initSite(ctx context.Context, cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	err = ui.Track("Configuring Continuous Deployment ... ", "Success! Whenever you push to git, Netlify will build and deploy your site", func() error {
+	err = ui.TrackWithTracker("Configuring Continuous Deployment ... ", "Success! Whenever you push to git, Netlify will build and deploy your site", tt, func() error {
 		client := context.GetClient(ctx)
 		key, err := client.CreateDeployKey(ctx)
 		if err != nil {

--- a/ui/task_tracker.go
+++ b/ui/task_tracker.go
@@ -20,7 +20,11 @@ type TaskTracker struct {
 }
 
 func NewTaskTracker() *TaskTracker {
-	if Term {
+	return NewTaskTrackerWithTerm(Term)
+}
+
+func NewTaskTrackerWithTerm(term bool) *TaskTracker {
+	if term {
 		s := spinner.New(progressIndicator, 300*time.Millisecond)
 		return &TaskTracker{s}
 	}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -92,8 +92,12 @@ func ConfirmOverwriteSite() bool {
 	return AskForConfirmation("There's already a site ID stored for this folder. Ignore and create a new site?")
 }
 
-func Track(process, success string, task func() error) (err error) {
+func Track(process, success string, task func() error) error {
 	tt := NewTaskTracker()
+	return TrackWithTracker(process, success, tt, task)
+}
+
+func TrackWithTracker(process, success string, tt *TaskTracker, task func() error) (err error) {
 	defer func() {
 		if err != nil {
 			tt.Failure(process)


### PR DESCRIPTION
Otherwise, the term hangs forever without allowing users to add inputs.

Fixes #91

Signed-off-by: David Calavera <david.calavera@gmail.com>