### PR TITLE
Forms Functionality: Be able to view forms and submissions

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"github.com/netlify/netlifyctl/commands/assets"
 	"github.com/netlify/netlifyctl/commands/deploy"
+	"github.com/netlify/netlifyctl/commands/forms"
 	initC "github.com/netlify/netlifyctl/commands/init"
 	"github.com/netlify/netlifyctl/commands/login"
 	"github.com/netlify/netlifyctl/commands/middleware"
@@ -29,6 +30,7 @@ func addCommands() {
 	rootCmd.AddCommand(deploy.Setup(siteMiddlewares))
 	rootCmd.AddCommand(assets.Setup(siteMiddlewares))
 	rootCmd.AddCommand(sites.Setup(middlewares))
+	rootCmd.AddCommand(forms.Setup(middlewares))
 	rootCmd.AddCommand(initC.Setup(middlewares))
 	rootCmd.AddCommand(login.Setup(loginMiddlewares))
 	rootCmd.AddCommand(versionCmd)

--- a/commands/forms/forms.go
+++ b/commands/forms/forms.go
@@ -1,0 +1,46 @@
+package forms
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/netlify/netlifyctl/commands/middleware"
+	"github.com/netlify/netlifyctl/context"
+	"github.com/spf13/cobra"
+)
+
+func Setup(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "form",
+		Aliases: []string{"forms", "f"},
+		Short:   "List forms",
+		Long:    "List forms",
+	}
+
+	cmd.AddCommand(setupFormSubmissions(middlewares))
+
+	return middleware.SetupCommand(cmd, listForms, middlewares)
+}
+
+func listForms(ctx context.Context, cmd *cobra.Command, args []string) error {
+	client := context.GetClient(ctx)
+
+	forms, err := client.ListForms(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	t := tabwriter.NewWriter(os.Stdout, 0, 10, 5, ' ', 0)
+	buffer := new(bytes.Buffer)
+
+	fmt.Fprintf(buffer, "Form Name\tForm ID\tSite ID\tSubmissions\n")
+	for _, f := range forms {
+		fmt.Fprintf(buffer, "%s\t%s\t%s\t%d\n", f.Name, f.ID, f.SiteID, f.SubmissionCount)
+	}
+	buffer.WriteTo(t)
+	t.Flush()
+
+	return nil
+}

--- a/commands/forms/submissions.go
+++ b/commands/forms/submissions.go
@@ -1,0 +1,56 @@
+package forms
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/netlify/netlifyctl/commands/middleware"
+	"github.com/netlify/netlifyctl/context"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type submissionsCmd struct {
+	formID string
+}
+
+func setupFormSubmissions(middlewares []middleware.Middleware) *cobra.Command {
+	cmd := &submissionsCmd{}
+	ccmd := &cobra.Command{
+		Use:   "submissions <-i FORM_ID> ...",
+		Short: "list form submissions",
+		Long:  "list form submissions",
+	}
+	ccmd.Flags().StringVarP(&cmd.formID, "form-id", "i", "", "form's id")
+
+	return middleware.SetupCommand(ccmd, cmd.listFormSubmissions, middlewares)
+}
+
+func (sc *submissionsCmd) listFormSubmissions(ctx context.Context, cmd *cobra.Command, args []string) error {
+	formID, err := cmd.Flags().GetString("form-id")
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to get string flag: 'form-id'")
+	}
+
+	client := context.GetClient(ctx)
+
+	submissions, err := client.ListFormSubmissions(ctx, formID)
+
+	if err != nil {
+		return err
+	}
+
+	t := tabwriter.NewWriter(os.Stdout, 0, 10, 5, ' ', 0)
+	buffer := new(bytes.Buffer)
+
+	fmt.Fprintf(buffer, "Timestamp\tName\tBody\n")
+	for _, f := range submissions {
+		fmt.Fprintf(buffer, "%s\t%s\t%s\n", f.CreatedAt, f.Name, f.Body)
+	}
+	buffer.WriteTo(t)
+	t.Flush()
+
+	return nil
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7d45421642e50711cb6925a6c00b2e8f7bca5f36c1ae0c9a091031beb6c09e4f
-updated: 2018-04-10T07:32:27.567685511-07:00
+hash: 10f42289ff6bddd2c285c41e835387294c3c922514ba9fca45179600405ebd6e
+updated: 2018-04-21T12:46:57.091428301-04:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: ca5f9e638c83bac66bfac70ded5bded1503135a7
@@ -105,7 +105,7 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/netlify/open-api
-  version: d65c0055e8177fd4abfed79b1ba8ef5998bff9ca
+  version: d4f58f35c43f0be6e8389c6cbe46bc79f3263e28
   vcs: git
   subpackages:
   - go/models

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   - client
 - package: github.com/go-openapi/strfmt
 - package: github.com/netlify/open-api
-  version: d65c0055e8177fd4abfed79b1ba8ef5998bff9ca
+  version: d4f58f35c43f0be6e8389c6cbe46bc79f3263e28
   vcs: git
   subpackages:
   - go/models


### PR DESCRIPTION
It was suggested in Issue #6 and I have added a new command and one subcommand to netlifyctl: `$ netlifyctl form`.

Running the forms command will list out every form a user has access to with the following fields: form name, form id, site id, and number of submissions.

As well, you can view basic details of form submissions as follows:

```
$ netlify form submissions --form-id <form-id string>
```

That will return a list of the submission timestamp, name, and body.