### PR TITLE
Add site with redirects for consistent latest-release URLs

### DIFF
--- a/site/_redirects
+++ b/site/_redirects
@@ -1,0 +1,9 @@
+/download/latest/mac         https://github.com/netlify/netlifyctl/releases/download/v0.3.3/netlifyctl-darwin-amd64-0.3.3.tar.gz  302
+/download/latest/linux       https://github.com/netlify/netlifyctl/releases/download/v0.3.3/netlifyctl-linux-amd64-0.3.3.tar.gz   302
+/download/latest/windows     https://github.com/netlify/netlifyctl/releases/download/v0.3.3/netlifyctl-windows-amd64-0.3.3.zip    302
+
+/download/latest/source-zip  https://github.com/netlify/netlifyctl/archive/v0.3.3.zip                                             302
+/download/latest/source-tar  https://github.com/netlify/netlifyctl/archive/v0.3.3.tar.gz                                          302
+
+/download/*                  https://github.com/netlify/netlifyctl/releases
+/*                           https://github.com/netlify/netlifyctl


### PR DESCRIPTION
This adds a `site` folder with a single `_redirects` file. When published to Netlify, this generates redirects from consistent "latest" URLs to the direct download links for the latest release.

You can test the redirects in the branch deploy:

https://latest-release-redirects--cli.netlify.com/download/latest/mac
https://latest-release-redirects--cli.netlify.com/download/latest/linux
https://latest-release-redirects--cli.netlify.com/download/latest/windows
https://latest-release-redirects--cli.netlify.com/download/latest/source-zip
https://latest-release-redirects--cli.netlify.com/download/latest/source-tar

All of these redirects are 302 temporary, since they'll change with each new release. At the moment, the change will have to be manual, but we can add a script to automate it later.

I also added a couple of catch-all redirects pointing to the releases page and the repo readme, in case they're useful. You can test these, too:

https://latest-release-redirects--cli.netlify.com
https://latest-release-redirects--cli.netlify.com/download