### PR TITLE
Don't append extra .git extension in repository URL if it already exists

### DIFF
--- a/commands/init/manual.go
+++ b/commands/init/manual.go
@@ -47,7 +47,10 @@ func (c manualConfigurator) RepoInfo(ctx context.Context) (*models.RepoInfo, err
 			return nil, errors.Wrapf(err, "invalid repository url: %s", repoPath)
 		}
 		hp := strings.SplitN(p.Host, ":", 2)
-		repoPath = fmt.Sprintf("git@%s:%s.git", hp[0], strings.TrimPrefix(p.Path, "/"))
+		repoPath = fmt.Sprintf("git@%s:%s", hp[0], strings.TrimPrefix(p.Path, "/"))
+		if !strings.HasSuffix(repoPath, ".git") {
+			repoPath = fmt.Sprintf("%s.git", repoPath)
+		}
 	}
 
 	return &models.RepoInfo{

--- a/commands/init/manual_test.go
+++ b/commands/init/manual_test.go
@@ -26,3 +26,22 @@ func TestRepoInfo(t *testing.T) {
 		require.ElementsMatch(t, []string{"master"}, r.AllowedBranches)
 	})
 }
+
+func TestRepoInfoWithGitExtension(t *testing.T) {
+	t.Run("repo info with http remote", func(t *testing.T) {
+		i := &gitRepo{
+			Remote:        "https://github.com/calavera/test.git",
+			URL:           &url.URL{Host: "github.com", Path: "calavera/test"},
+			CurrentBranch: "master",
+		}
+
+		m := manualConfigurator{i}
+		r, err := m.RepoInfo(context.Background())
+		require.NoError(t, err)
+
+		require.Equal(t, "git@github.com:calavera/test.git", r.RepoPath)
+		require.Equal(t, "manual", r.Provider)
+		require.Equal(t, "master", r.RepoBranch)
+		require.ElementsMatch(t, []string{"master"}, r.AllowedBranches)
+	})
+}


### PR DESCRIPTION
I was running into an issue where `netlifyctl init --manual` was appending an extra ".git" extension to the repository URL.

Take this git remote for example:

```bash
[remote "origin"]
  url = https://github.com/jakebellacera/example.git
```

This was causing the "Repository" property to be set as:

```
git@github.com:jakebellacera/example.git.git
```

... which is invalid.

<img width="931" alt="screen shot 2018-07-13 at 1 15 28 pm" src="https://user-images.githubusercontent.com/391085/42712090-16e76898-869f-11e8-834e-975720a8e738.png">

This PR simply checks if the `repoUrl` ends with ".git", and if it doesn’t, then it will append it.