### PR TITLE
Bump Netlify open-api version

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 96ee2ffd0a3f2f50c6af949d0d3d749976390bde7f9f8b658f0e622837f6362d
-updated: 2018-06-09T11:15:34.079536839-07:00
+hash: 8702acdf22648c12a229a9878428f0c90efd559f0bc12d8bef6c2ae57350ce12
+updated: 2018-09-24T13:47:34.383569-07:00
 imports:
 - name: github.com/asaskevich/govalidator
-  version: ca5f9e638c83bac66bfac70ded5bded1503135a7
+  version: f682aee18e37332521b3c3ef4cba9ddb9b516b09
 - name: github.com/Azure/go-autorest
   version: 809ed2ef5c4c9a60c3c2f3aa9cc11f3a7c2ce59d
   subpackages:
@@ -13,19 +13,24 @@ imports:
   version: b2e0b668d1ae4a3959df7d1ed2c18927d65ad1e1
   repo: https://github.com/calavera/spinner
 - name: github.com/BurntSushi/toml
-  version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
+  version: 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005
 - name: github.com/cenkalti/backoff
-  version: 61ba96c4d1002f22e06acb8e34a7650611125a63
+  version: 309aa717adbf351e92864cbedf9cca0b769a4b5a
 - name: github.com/dgrijalva/jwt-go
   version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
-- name: github.com/fatih/color
-  version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
-- name: github.com/fhs/go-netrc
-  version: 4ffed54ee5c32ebfb1b8c7c72fc90bb08dc3ff43
+- name: github.com/emirpasic/gods
+  version: 1615341f118ae12f353cc8a983f35b584342c9b3
   subpackages:
-  - netrc
+  - containers
+  - lists
+  - lists/arraylist
+  - trees
+  - trees/binaryheap
+  - utils
+- name: github.com/fatih/color
+  version: 2d684516a8861da43017284349b7e303e809ac21
 - name: github.com/github/hub
-  version: 5ce945e74713efe782cc10dc2fc08ea0b4fe099d
+  version: de684cb613c47572cc9ec90d4fd73eef80aef09c
   subpackages:
   - cmd
   - git
@@ -42,7 +47,7 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 36d33bfe519efae5632669801b180bf1a245da3b
 - name: github.com/go-openapi/loads
-  version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
+  version: c3e1ca4c0b6160cac10aeef7e8b425cc95b9c820
 - name: github.com/go-openapi/runtime
   version: 96511efa8f2190cf4dd04412c61a1a96546b36d9
   subpackages:
@@ -54,15 +59,15 @@ imports:
   - middleware/untyped
   - security
 - name: github.com/go-openapi/spec
-  version: 48c2a7185575f9103a5a3863eff950bb776899d2
+  version: a4fa9574c7aa73b2fc54e251eb9524d0482bb592
 - name: github.com/go-openapi/strfmt
   version: 610b6cacdcde6852f4de68998bd20ce1dac85b22
 - name: github.com/go-openapi/swag
-  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
+  version: cf0bdb963811675a4d7e74901cefc7411a1df939
 - name: github.com/go-openapi/validate
-  version: dc8a684882cf70c9a529887104340f44e0e138e5
+  version: d509235108fcf6ab4913d2dcb3a2260c0db2108e
 - name: github.com/golang/protobuf
-  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
+  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
   subpackages:
   - proto
 - name: github.com/google/go-github
@@ -70,7 +75,7 @@ imports:
   subpackages:
   - github
 - name: github.com/google/go-querystring
-  version: 53e6ce116135b80d037921a7fdd5138cf32d7a8a
+  version: 44c6ddd0a2342c386950e880b658017258da92fc
   subpackages:
   - query
 - name: github.com/inconshreveable/mousetrap
@@ -79,34 +84,26 @@ imports:
   version: d14ea06fba99483203c19d92cfcd13ebe73135f4
   subpackages:
   - io
-- name: github.com/jingweno/go-sawyer
-  version: 1999ae5763d678f3ce1112cf1fda7c7e9cf2aadf
-  subpackages:
-  - hypermedia
-  - mediaheader
-  - mediatype
-- name: github.com/jtacoma/uritemplates
-  version: 307ae868f90f4ee1b73ebe4596e0394237dacce8
 - name: github.com/kballard/go-shellquote
-  version: cd60e84ee657ff3dc51de0b4f55dd299a3e136f2
+  version: 95032a82bc518f77982ea72343cc1ade730072f0
+- name: github.com/kevinburke/ssh_config
+  version: 81db2a75821ed34e682567d48be488a1c3121088
 - name: github.com/mailru/easyjson
-  version: 2a92e673c9a6302dd05c3a691ae1f24aef46457d
+  version: 32fa128f234d041f196a9f3e0fea5ac9772c08e1
   subpackages:
   - buffer
   - jlexer
   - jwriter
 - name: github.com/mattn/go-colorable
-  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
-  repo: https://github.com/mattn/go-colorable
+  version: efa589957cd060542a26d2dd7832fd6a6c6c3ade
 - name: github.com/mattn/go-isatty
-  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
-  repo: https://github.com/mattn/go-isatty
+  version: 3fb116b820352b7f0c281308a4d6250c22d94e27
 - name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: ae18d6b8b3205b561c79e8e5f69bff09736185f4
 - name: github.com/mitchellh/mapstructure
-  version: db1efb556f84b25a0a13a04aad883943538ad2e0
+  version: 06020f85339e21b2478f756a78e295255ffa4d6a
 - name: github.com/netlify/open-api
-  version: 09203f5c1873bd4124acdd7929651cb29d2bc3c2
+  version: c538e1097640e72fe7ccb7114ba88a1058f5a5a0
   vcs: git
   subpackages:
   - go/models
@@ -115,14 +112,12 @@ imports:
   - go/porcelain
   - go/porcelain/context
   - go/porcelain/http
-- name: github.com/octokit/go-octokit
-  version: 812e91dfbd64051c1ec72c48feda0278727e8a4e
-  subpackages:
-  - octokit
+- name: github.com/pelletier/go-buffruneio
+  version: de1592c34d9c6055a32fc9ebe2b3ee50ca468ebe
 - name: github.com/pkg/errors
-  version: 816c9085562cd7ee03e7f8188a1cfd942858cded
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/PuerkitoBio/purell
-  version: fd18e053af8a4ff11039269006e8037ff374ce0e
+  version: 1c4bec281e4bbc75b4f4a1bd923bdf1bd989a969
 - name: github.com/PuerkitoBio/urlesc
   version: de5bf2ad457846296e2031421a34e2568e304e35
 - name: github.com/rsc/goversion
@@ -130,7 +125,7 @@ imports:
   subpackages:
   - version
 - name: github.com/sergi/go-diff
-  version: 2fc9cd33b5f86077aa3e0f442fa0476a9fa9a1dc
+  version: da645544ed44df016359bd4c0e3dc60ee3a0da43
   subpackages:
   - diffmatchpatch
 - name: github.com/sirupsen/logrus
@@ -140,9 +135,9 @@ imports:
   subpackages:
   - open
 - name: github.com/spf13/cobra
-  version: fcd0c5a1df88f5d6784cb4feead962c3f3d0b66c
+  version: 7b2c5ac9fc04fc5efafb60700713d4fa609b777b
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/src-d/gcfg
   version: f187355171c936ac84a82793659ebb4936bc1c23
   subpackages:
@@ -152,25 +147,35 @@ imports:
 - name: github.com/xanzy/go-gitlab
   version: 8a20d674959fea44da3d253bdd883f2c3d280310
 - name: github.com/xanzy/ssh-agent
-  version: ba9c9e33906f58169366275e3450db66139a31a9
+  version: 640f0ab560aeb89d523bb6ac322b1244d5c3796c
 - name: golang.org/x/crypto
-  version: 687d4b818545e443c8ba223cbef20b1721afd4db
+  version: 0e37d006457bf46f9e6692014ba72ef82c33022c
   subpackages:
+  - cast5
   - curve25519
   - ed25519
   - ed25519/internal/edwards25519
+  - internal/chacha20
+  - internal/subtle
+  - openpgp
+  - openpgp/armor
+  - openpgp/elgamal
+  - openpgp/errors
+  - openpgp/packet
+  - openpgp/s2k
+  - poly1305
   - ssh
   - ssh/agent
   - ssh/knownhosts
   - ssh/terminal
 - name: golang.org/x/net
-  version: d379faa25cbdc04d653984913a2ceb43b0bc46d7
+  version: 9dfe39835686865bff950a07b394c12a98ddc811
   subpackages:
   - context
   - context/ctxhttp
   - idna
 - name: golang.org/x/oauth2
-  version: 9a379c6b3e95a790ffc43293c2a78dee0d7b6e20
+  version: d2e6202438beef2727060aa7cabdd924d92ebfd9
   subpackages:
   - internal
 - name: golang.org/x/sys
@@ -179,13 +184,15 @@ imports:
   - unix
   - windows
 - name: golang.org/x/text
-  version: f28f36722d5ef2f9655ad3de1f248e3e52ad5ebd
+  version: 905a57155faa8230500121607930ebb9dd8e139c
   subpackages:
+  - secure/bidirule
   - transform
+  - unicode/bidi
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: d9a072cfa7b9736e44311ef77b3e09d804bfa599
+  version: ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06
   subpackages:
   - internal
   - internal/base
@@ -199,15 +206,15 @@ imports:
   subpackages:
   - bson
   - internal/json
-- name: gopkg.in/src-d/go-billy.v3
-  version: c329b7bc7b9d24905d2bc1b85bfa29f7ae266314
+- name: gopkg.in/src-d/go-billy.v4
+  version: 982626487c60a5252e7d0b695ca23fb0fa2fd670
   subpackages:
   - helper/chroot
   - helper/polyfill
   - osfs
   - util
 - name: gopkg.in/src-d/go-git.v4
-  version: f9879dd043f84936a1f8acb8a53b74332a7ae135
+  version: d3cec13ac0b195bfb897ed038a08b5130ab9969e
   subpackages:
   - config
   - internal/revision
@@ -238,7 +245,7 @@ imports:
   - plumbing/transport/ssh
   - storage
   - storage/filesystem
-  - storage/filesystem/internal/dotgit
+  - storage/filesystem/dotgit
   - storage/memory
   - utils/binary
   - utils/diff
@@ -249,22 +256,20 @@ imports:
   - utils/merkletrie/internal/frame
   - utils/merkletrie/noder
 - name: gopkg.in/warnings.v0
-  version: 8a331561fe74dadba6edfc59f3be66c22c3b065d
-- name: gopkg.in/yaml.v1
-  version: 9f9df34309c04878acc86042b16630b0f696e1de
+  version: ec4a0fea49c7b46c2aeb0b51aac55779c607e52b
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: c679ae2cc0cb27ec3293fea7e254e47386f05d69
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
   - client
 - package: github.com/go-openapi/strfmt
 - package: github.com/netlify/open-api
-  version: 09203f5c1873bd4124acdd7929651cb29d2bc3c2
+  version: v0.4.2
   vcs: git
   subpackages:
   - go/models


### PR DESCRIPTION
We made several changes since we bumped the version last, so let's bump it.
Also use `vX.Y.Z` format.